### PR TITLE
Create M as and P as cached functions otherwise restrictions are persistent 

### DIFF
--- a/searoute/__init__.py
+++ b/searoute/__init__.py
@@ -1,3 +1,3 @@
-from .searoute import from_nodes_edges_set, searoute, P, M, marnet, ports
+from .searoute import from_nodes_edges_set, searoute, setup_P, setup_M, marnet, ports
 from .classes.marnet import Marnet
 from .classes.ports import Ports

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -3,8 +3,6 @@ from .classes import ports, marnet, passages
 from .utils import get_duration, distance_length, from_nodes_edges_set, normalize_linestring, validate_lon_lat
 from geojson import Feature, LineString
 
-from functools import cache
-
 def setup_P():
     from .data.ports_dict import edge_list as port_e, node_list as port_n
     return from_nodes_edges_set(ports.Ports(), port_n, port_e)

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -7,14 +7,10 @@ from functools import cache
 
 def setup_P():
     from .data.ports_dict import edge_list as port_e, node_list as port_n
-    print("setting up P")
-
     return from_nodes_edges_set(ports.Ports(), port_n, port_e)
 
 def setup_M():
     from .data.marnet_dict import edge_list as marnet_e, node_list as marnet_n
-    print("setting up M")
-
     return from_nodes_edges_set(marnet.Marnet(), marnet_n, marnet_e)
 
 

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -50,9 +50,9 @@ def searoute(origin, destination, units='km', speed_knot=24, append_orig_dest=Fa
     """
 
     if M is None:
-        M = setup_M()
+        M = copy(setup_M())
     if P is None:
-        P = setup_P()
+        P = copy(setup_P())
     # Validate origin input
     validate_lon_lat(origin)
     # Validate destination input

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -3,17 +3,23 @@ from .classes import ports, marnet, passages
 from .utils import get_duration, distance_length, from_nodes_edges_set, normalize_linestring, validate_lon_lat
 from geojson import Feature, LineString
 
-from .data.ports_dict import edge_list as port_e, node_list as port_n
-from .data.marnet_dict import edge_list as marnet_e, node_list as marnet_n
+from functools import cache
+
+def setup_P():
+    from .data.ports_dict import edge_list as port_e, node_list as port_n
+    print("setting up P")
+
+    return from_nodes_edges_set(ports.Ports(), port_n, port_e)
+
+def setup_M():
+    from .data.marnet_dict import edge_list as marnet_e, node_list as marnet_n
+    print("setting up M")
+
+    return from_nodes_edges_set(marnet.Marnet(), marnet_n, marnet_e)
 
 
-P = from_nodes_edges_set(ports.Ports(), port_n, port_e)
-M = from_nodes_edges_set(marnet.Marnet(), marnet_n, marnet_e)
 
-del port_e, port_n, marnet_e, marnet_n
-
-
-def searoute(origin, destination, units='km', speed_knot=24, append_orig_dest=False, restrictions=[passages.Passage.northwest], include_ports=False, port_params={}, M:marnet.Marnet=M, P:ports.Ports=P):
+def searoute(origin, destination, units='km', speed_knot=24, append_orig_dest=False, restrictions=[passages.Passage.northwest], include_ports=False, port_params={}, M:marnet.Marnet=None, P:ports.Ports=None):
     """
     Calculates the shortest sea route between two points on Earth.
 
@@ -40,6 +46,10 @@ def searoute(origin, destination, units='km', speed_knot=24, append_orig_dest=Fa
     a Feature (geojson) of a LineString of sea route with parameters : `unit` and `length`, `duration_hours` or port details
     """
 
+    if M is None:
+        M = setup_M()
+    if P is None:
+        P = setup_P()
     # Validate origin input
     validate_lon_lat(origin)
     # Validate destination input

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -3,13 +3,22 @@ from .classes import ports, marnet, passages
 from .utils import get_duration, distance_length, from_nodes_edges_set, normalize_linestring, validate_lon_lat
 from geojson import Feature, LineString
 
+from functools import cache
+from copy import copy
+
+@cache
 def setup_P():
     from .data.ports_dict import edge_list as port_e, node_list as port_n
+    print("Setting up ports")
     return from_nodes_edges_set(ports.Ports(), port_n, port_e)
 
+@cache
 def setup_M():
+    print("Setting up marnet")
     from .data.marnet_dict import edge_list as marnet_e, node_list as marnet_n
     return from_nodes_edges_set(marnet.Marnet(), marnet_n, marnet_e)
+
+
 
 
 

--- a/searoute/searoute.py
+++ b/searoute/searoute.py
@@ -9,12 +9,10 @@ from copy import copy
 @cache
 def setup_P():
     from .data.ports_dict import edge_list as port_e, node_list as port_n
-    print("Setting up ports")
     return from_nodes_edges_set(ports.Ports(), port_n, port_e)
 
 @cache
 def setup_M():
-    print("Setting up marnet")
     from .data.marnet_dict import edge_list as marnet_e, node_list as marnet_n
     return from_nodes_edges_set(marnet.Marnet(), marnet_n, marnet_e)
 


### PR DESCRIPTION
- Currently `M` and `P` are as default arguments (https://github.com/genthalili/searoute-py/blob/85c395fa7dbe9111ad91101bc3aa49079229577d/searoute/searoute.py#L16) , in python default arguments should not be mutable, so we make them None and then initialise in the function. 


This PR fixes a bug that can occur when using restrictions currently if you 
1. Solve with no restriction `restrictions=None`
2. Solve with a restriction `restrictions = ['suez']`

Then if you solve with no restriction `restrictions=None` it keeps the suez restriction. 

Here is an MWE for the problem 
```python
import searoute as sr
import folium


src_lat = -15.46667
src_lon = 28.26667
dst_lat = 51.5
dst_lon = -0.1666667
b = sr.searoute(
    [src_lon, src_lat],
    [dst_lon, dst_lat],
    include_ports=True,
    port_params=dict(
        country_pol="ZM",
        country_pod="GB"
    ),
    restrictions = None
)
d = sr.searoute(
    [src_lon, src_lat],
    [dst_lon, dst_lat],
    include_ports=True,
    port_params=dict(
        country_pol="ZM",
        country_pod="GB"
    ),
    restrictions = ['suez']
)
nb = sr.searoute(
    [src_lon, src_lat],
    [dst_lon, dst_lat],
    include_ports=True,
    port_params=dict(
        country_pol="ZM",
        country_pod="GB"
    ),
    restrictions = None
)
# Swap coord order for folium
b['geometry']['coordinates'] = [list(reversed(coord)) for coord in b['geometry']['coordinates']]
d['geometry']['coordinates'] = [list(reversed(coord)) for coord in d['geometry']['coordinates']]
nb['geometry']['coordinates'] = [list(reversed(coord)) for coord in nb['geometry']['coordinates']]

m = folium.Map(location=[0,0],zoom_start=3)
folium.PolyLine(b['geometry']['coordinates'], color="blue", weight=2.5, opacity=1).add_to(m)
folium.PolyLine(d['geometry']['coordinates'], color="red", weight=2.5, opacity=1).add_to(m)
folium.PolyLine(nb['geometry']['coordinates'], color="black", weight=2.5, opacity=0.5).add_to(m)

m
```
You can see the disrupted and the second undisrupted go via the horn of Africa while the first undisrupted uses the Suez canal

![SCR-20240605-lkia](https://github.com/genthalili/searoute-py/assets/59419126/33d5d203-7d0f-4262-8280-3b02a2ddff03)
