### PR TITLE
Enforce route restrictions using subgraph

### DIFF
--- a/searoute/classes/marnet.py
+++ b/searoute/classes/marnet.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import warnings
 from .passages import Passage
 from ..utils import load_from_geojson, distance
 from .kdtree import KDTree
@@ -105,15 +106,6 @@ class Marnet(nx.Graph):
         else:
             return self
 
-    def custom_weight(self, u, v, edge_data):
-        # Function to customize edge weight based on edge attributes or conditions
-        # For this example, we will avoid edges with a certain attribute (e.g., "avoid": True)
-        edge_values = edge_data.values()
-        avoid_edge = any(value.get('passage', None) in (
-            self.restrictions) for value in edge_values)
-        wights = [value.get('weight', 1.0) for value in edge_values]
-        return float('inf') if avoid_edge else min(wights)
-
     def filter_avoid_passages(self, u, v, edge_data, args):
         edge_values = edge_data.values()
 
@@ -132,10 +124,6 @@ class Marnet(nx.Graph):
         else:
             self.kdtree = KDTree(self._node)
 
-    # Get the shortest route by distance
-    def __custom_w(self, u, v, data):
-        return data.get('weight') if data.get('passage') not in self.restrictions else float('inf')
-
     def shortest_path(self, origin, destination):
         """
         Shortest Path between the origin and the destination.
@@ -150,14 +138,30 @@ class Marnet(nx.Graph):
 
         Returns
         -------
-        A list of nodes building the shortest path
+        A list of nodes building the shortest path, or None if no path exits
         
         """
         origin_node = self.kdtree.query(origin)
         destination_node = self.kdtree.query(destination)
 
-        return nx.shortest_path(
-            self, origin_node, destination_node, weight=self.__custom_w) 
+        def filter_edge(u, v):
+            edge_data = self.get_edge_data(u, v)
+            passage = edge_data.get('passage', None)
+            return passage not in self.restrictions
+        
+        # create subgraph view without restricted edges
+        filtered_graph = nx.subgraph_view(self, filter_edge=filter_edge)
+
+        try:
+            return nx.shortest_path(
+                filtered_graph, origin_node, destination_node, weight='weight')
+        except nx.NetworkXNoPath:
+            warnings.warn(
+                f"No path found between {origin} and {destination}. "
+                f"The route may be blocked by passage restrictions: {self.restrictions}",
+                UserWarning
+            )
+            return None # No path exists
 
     @staticmethod
     def from_geojson(*path):

--- a/test.py
+++ b/test.py
@@ -16,3 +16,11 @@ print(route)
 # Defaults to km, can be can be 'm' = meters 'mi = miles 'ft' = feets 'in' = inches 'deg' = degrees
 # 'cen' = centimeters 'rad' = radians 'naut' = nauticals 'yd' = yards
 routeMiles = sr.searoute(origin, destination, units="mi")
+
+# Define origin and destination points that would be affected by complete closure
+origin=(103.85457, 1.25760) # Singapore - SGSIN
+destination=(23.62904, 37.94056) # Piraeus - GRPIR
+
+closed_route = sr.searoute(origin, destination, restrictions=['suez', 'gibraltar'], return_passages=True)
+
+print(closed_route)


### PR DESCRIPTION
This pull request refactors how passage restrictions are handled when calculating the shortest path in the `Marnet` class. Instead of using custom weight functions to avoid restricted passages, it now leverages a filtered subgraph that excludes restricted edges. It raises a warning when no path exists due to restrictions. Additionally, test code has been updated to demonstrate passage closure scenarios.

**Refactoring of passage restriction handling:**

* Replaced the custom weight functions (`custom_weight` and `__custom_w`) with a subgraph filter using `nx.subgraph_view` to exclude edges with restricted passages in `shortest_path`, simplifying the logic for handling restrictions. [[1]](diffhunk://#diff-659a2b0edf89368ad3de203c22b8ed4014ca7183498652245caca67fbb9e6eeaL108-L116) [[2]](diffhunk://#diff-659a2b0edf89368ad3de203c22b8ed4014ca7183498652245caca67fbb9e6eeaL135-L138) [[3]](diffhunk://#diff-659a2b0edf89368ad3de203c22b8ed4014ca7183498652245caca67fbb9e6eeaL153-R164).

* Given that the shortest distance is calculated on a subgraph *view*, the original graph is left unchanged. 

**Error handling improvements:**

* Added warnings when no path is found due to passage restrictions, returning `None` instead of raising an exception in `shortest_path`. This respects the current architecture in `searoute.py`.

**Testing enhancements:**

* Updated `test.py` to include a test case for routing with closed passages, demonstrating the effect of passage restrictions on route calculation.